### PR TITLE
feat: edited the breadcrumb component to include choosing a principe

### DIFF
--- a/src/lib/components/addForm.svelte
+++ b/src/lib/components/addForm.svelte
@@ -129,7 +129,7 @@
 			for (const part of parts) {
 				if (!part.startsWith('data:')) continue;
 				const { status, type, error, count, total } = JSON.parse(part.replace(/^data:\s*/, ''));
-				if (count && total){
+				if (count && total) {
 					urlCount = count;
 					urlTotal = total;
 				}
@@ -402,7 +402,7 @@
 			<div class="tip-message" aria-label="tip message">
 				<p><span>{nameValue}</span> wordt verwerkt, sluit de pagina niet.</p>
 			</div>
-			<Loader itemArray={logs} urlCount={urlCount} urlTotal={urlTotal} type={type} />
+			<Loader itemArray={logs} {urlCount} {urlTotal} {type} />
 		{/if}
 	</section>
 </dialog>

--- a/src/lib/components/breadCrumbs.svelte
+++ b/src/lib/components/breadCrumbs.svelte
@@ -2,11 +2,15 @@
 	export let params;
 	export let partners;
 	export let websites;
+	export let principes;
 
 	$: selectedPartner = params.websiteUID
 		? partners.websites.find(({ slug }) => slug === params.websiteUID)
 		: '';
 	$: selectedUrl = params.urlUID ? params.urlUID : '';
+	$: selectedPrincipe = params.principeUID
+		? principes.find(({ slug }) => slug === params.principeUID)
+		: '';
 
 	const faviconAPI =
 		'https://t1.gstatic.com/faviconV2?client=SOCIAL&type=FAVICON&fallback_opts=TYPE,SIZE,URL&url=';
@@ -16,27 +20,31 @@
 	<div class="dropdown">
 		<button>
 			{#if selectedPartner}
-				<img
-					width="24"
-					src="{faviconAPI}{selectedPartner.homepage}/&size=128"
-					alt="logo partner"
-				/>{selectedPartner.titel}
+				<span>
+					<img
+						width="24"
+						src="{faviconAPI}{selectedPartner.homepage}/&size=128"
+						alt="logo partner"
+					/>{selectedPartner.titel}
+				</span>
 			{:else}
-				Partners overzicht
+				<span>Partners overzicht</span>
 			{/if}
 		</button>
 		<ul>
 			<li>
-				<a href="/">Partners overzicht</a>
+				<a href="/"><span>Partners overzicht</span></a>
 			</li>
 			{#each partners.websites as partner}
 				<li>
 					<a href="/{partner.slug}">
-						<img
-							width="24"
-							src="{faviconAPI}{partner.homepage}/&size=256"
-							alt="logo partner"
-						/>{partner.titel}
+						<span>
+							<img
+								width="24"
+								src="{faviconAPI}{partner.homepage}/&size=256"
+								alt="logo partner"
+							/>{partner.titel}
+						</span>
 					</a>
 				</li>
 			{/each}
@@ -48,18 +56,41 @@
 		<div class="dropdown">
 			<button>
 				{#if selectedUrl}
-					{selectedUrl}
+					<span>{selectedUrl}</span>
 				{:else}
-					<span>Websites overzicht</span>
+					<span>Urls overzicht</span>
 				{/if}
 			</button>
 			<ul>
 				<li>
-					<a href="/{selectedPartner.slug}">Websites overzicht</a>
+					<a href="/{selectedPartner.slug}"><span>Urls overzicht</span></a>
 				</li>
 				{#each websites.urls as website}
 					<li>
-						<a href="/{selectedPartner.slug}/{website.slug}">{website.slug}</a>
+						<a href="/{selectedPartner.slug}/{website.slug}"><span>{website.slug}</span></a>
+					</li>
+				{/each}
+			</ul>
+		</div>
+	{/if}
+
+	{#if selectedUrl && principes}
+		<span class="seperator">/</span>
+		<div class="dropdown">
+			<button>
+				{#if selectedPrincipe}
+					<span>{selectedPrincipe.titel}</span>
+				{:else}
+					<span>Principes overzicht</span>
+				{/if}
+			</button>
+			<ul>
+				<li>
+					<a href="/{selectedPartner.slug}/{selectedUrl}"><span>Principes overzicht</span></a>
+				</li>
+				{#each principes as principe}
+					<li>
+						<a href="/{selectedPartner.slug}/{selectedUrl}/{principe.slug}" data-sveltekit-reload><span>{principe.titel}</span></a>
 					</li>
 				{/each}
 			</ul>
@@ -80,15 +111,13 @@
 		align-items: center;
 		gap: 0.5rem;
 		appearance: none;
-		padding: 1em 0.6em;
-		padding-right: 4em;
-		border-radius: 0.5em;
-		font-size: 1em;
+		padding: 1rem 0.5rem;
+		border-radius: 0.5rem;
+		font-size: 1rem;
 		background-color: var(--c-container);
 		color: var(--c-grey);
 		border: none;
 		width: 100%;
-		height: 3.5rem;
 		text-align: left;
 		box-shadow: 0px -55px 0px 10px var(--c-background);
 	}
@@ -101,18 +130,28 @@
 		transition: 0.2s;
 	}
 
+	button span, a span {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		width: 15ch;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
 	.dropdown {
 		position: relative;
 		display: inline-block;
-		min-width: 19rem;
+		min-width: 12rem;
 		height: max-content;
 		z-index: 1;
 	}
 
 	.dropdown img {
 		border-radius: 4px;
-		height: 24px;
-		width: 24px;
+		height: 1.5rem;
+		width: 1.5rem;
 	}
 
 	.seperator {
@@ -132,8 +171,8 @@
 		z-index: -1;
 	}
 
-	ul li:first-child {
-		border-bottom: 1px solid;
+	ul li:nth-child(2) {
+		border-top: 1px solid;
 	}
 
 	ul a {
@@ -155,10 +194,6 @@
 	ul a:hover {
 		background-color: var(--c-white);
 		color: var(--c-text-header);
-	}
-
-	ul a:hover img {
-		transform: translateY(-3px);
 	}
 
 	.dropdown:hover ul {

--- a/src/lib/components/breadCrumbs.svelte
+++ b/src/lib/components/breadCrumbs.svelte
@@ -90,7 +90,9 @@
 				</li>
 				{#each principes as principe}
 					<li>
-						<a href="/{selectedPartner.slug}/{selectedUrl}/{principe.slug}" data-sveltekit-reload><span>{principe.titel}</span></a>
+						<a href="/{selectedPartner.slug}/{selectedUrl}/{principe.slug}"
+							><span>{principe.titel}</span></a
+						>
 					</li>
 				{/each}
 			</ul>
@@ -130,7 +132,8 @@
 		transition: 0.2s;
 	}
 
-	button span, a span {
+	button span,
+	a span {
 		display: flex;
 		align-items: center;
 		gap: 0.5rem;

--- a/src/lib/components/header.svelte
+++ b/src/lib/components/header.svelte
@@ -7,6 +7,7 @@
 	export let params;
 	export let partners;
 	export let websites;
+	export let principes;
 	export let user = null;
 
 	let isLightMode = false;
@@ -62,7 +63,7 @@
 			/>
 		</a>
 		{#if user}
-			<BreadCrumbs {params} {partners} {websites} />
+			<BreadCrumbs {params} {partners} {websites} {principes} />
 		{/if}
 		<div class="options">
 			{#if user}

--- a/src/lib/components/loader.svelte
+++ b/src/lib/components/loader.svelte
@@ -26,9 +26,9 @@
 		<p>Logs ({logCount})</p>
 		{#if type !== 1}
 			{#if urlCount && urlTotal}
-				<p><span class="loader"></span>Urls ({urlCount}/{urlTotal})</p>
+				<p><span class="loader" />Urls ({urlCount}/{urlTotal})</p>
 			{:else}
-				<p><span class="loader"></span>Aantal urls ophalen...</p>
+				<p><span class="loader" />Aantal urls ophalen...</p>
 			{/if}
 		{/if}
 	</summary>
@@ -36,7 +36,7 @@
 		{#each itemArray as item}
 			<li class="log-item {item.type}">
 				{#if item.type === 'loading'}
-					<span class="loader"></span>
+					<span class="loader" />
 				{:else}
 					<img src="/icons/{item.type}.svg" alt={item.type} width="16" height="16" />
 				{/if}

--- a/src/lib/utils/sitemap.js
+++ b/src/lib/utils/sitemap.js
@@ -107,7 +107,12 @@ export async function processUrls(urls, slug, sendUpdate) {
 		const link = urls[i];
 		const path = new URL(link).pathname;
 		let urlSlug = (slug + path).replace(/\//g, '-');
-		await sendUpdate({ status: `Verwerk URL ${i + 1}/${urls.length}`, type: 'done', count: i + 1, total: urls.length });
+		await sendUpdate({
+			status: `Verwerk URL ${i + 1}/${urls.length}`,
+			type: 'done',
+			count: i + 1,
+			total: urls.length
+		});
 		await delay(250);
 
 		try {

--- a/src/routes/+layout.server.js
+++ b/src/routes/+layout.server.js
@@ -2,15 +2,18 @@ import { gql } from 'graphql-request';
 import { hygraph } from '$lib/utils/hygraph.js';
 import getQueryPartner from '$lib/queries/partner';
 import getQueryWebsite from '$lib/queries/website';
+import getQueryPrincipes from '$lib/queries/principes.js';
 
 export async function load({ params, locals }) {
 	let { websiteUID } = params;
 	const queryPartner = getQueryPartner(gql);
 	const queryWebsite = getQueryWebsite(gql, websiteUID);
+	const queryPrincipes = getQueryPrincipes(gql);
 
 	return {
 		gebruiker: locals.gebruiker,
 		partnersData: await hygraph.request(queryPartner),
-		websitesData: await hygraph.request(queryWebsite)
+		websitesData: await hygraph.request(queryWebsite),
+		principesData: await hygraph.request(queryPrincipes)
 	};
 }

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -7,6 +7,7 @@
 
 	$: params = $page.params;
 	$: websites = data.websitesData.website;
+	$: principes = data.principesData.principes;
 
 	let partners = data.partnersData;
 
@@ -22,7 +23,7 @@
 	});
 </script>
 
-<Header {params} {partners} {websites} user={data.gebruiker} />
+<Header {params} {partners} {websites} {principes} user={data.gebruiker} />
 
 <main id="main">
 	<slot />

--- a/src/routes/[websiteUID]/[urlUID]/[principeUID]/+page.svelte
+++ b/src/routes/[websiteUID]/[urlUID]/[principeUID]/+page.svelte
@@ -12,10 +12,10 @@
 		url: data.urlData.url.slug
 	};
 
-	const toolboardData = data.toolboardData;
-	const urlData = data.urlData;
-	const richtlijnen = toolboardData.principe.richtlijnen;
-	const principes = data.toolboardData.principes;
+	$: toolboardData = data.toolboardData;
+	$: urlData = data.urlData;
+	$: richtlijnen = toolboardData.principe.richtlijnen;
+	$: principes = data.toolboardData.principes;
 </script>
 
 <Heading {heading} />


### PR DESCRIPTION
## What does this change?

Resolves issue #129 

The breadcrumbs component is edited to include a list of principes you can choose for the selected url of a partner.
This wa you can quickly navigate through each principe without having to go back a page each time.
The styling is also slighty changed to make each dropdown container smaller in width and padding so they don't take over the entire header.

## How Has This Been Tested?

- [x] [User test]()
- [ ] [Accessibility test]()
- [x] [Performance test]()
- [x] [Responsive Design test]()
- [x] [Device test]()
- [x] [Browser test]()

## Images

![image](https://github.com/user-attachments/assets/81606180-1ef7-4fa3-a962-6a3e060fe355)
![image](https://github.com/user-attachments/assets/a199c9ac-51fa-448d-b686-39c9816e9ae6)

## How to review

Check if you can navigate between each principe of the selected url of a partner.
